### PR TITLE
Remove second locked-in-place toolbar button

### DIFF
--- a/Firefox/content/browser.xul
+++ b/Firefox/content/browser.xul
@@ -9,8 +9,4 @@
     <toolbarpalette id="BrowserToolbarPalette">
         <toolbarbutton id="livereload-button" label="LR" tooltiptext="Enable LiveReload" image="chrome://livereload/skin/IconDisabled.png"  type="button" class="toolbarbutton-1 chromeclass-toolbar-additional" style="-moz-image-region: rect(0, 16px, 16px, 0);"/>
     </toolbarpalette>
-
-    <toolbar id="nav-bar">
-        <toolbarbutton id="livereload-button" label="LR" tooltiptext="Enable LiveReload" image="chrome://livereload/skin/IconDisabled.png"  type="button" class="toolbarbutton-1 chromeclass-toolbar-additional" style="" />
-    </toolbar>
 </overlay>


### PR DESCRIPTION
Fix for #17, read https://github.com/livereload/livereload-extensions/issues/17#issuecomment-41976963. Also for #28.
